### PR TITLE
Remove `timeout` from pytest config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [tool:pytest]
 testpaths = tests
-timeout = 10
 filterwarnings = error
 
 [flake8]


### PR DESCRIPTION
With the directive in place, pytest v6+ would fail with `pytest.PytestConfigWarning: Unknown config option: timeout`.

Since some CI steps install pytest 6.x automatically, those steps fail.

Fixes #12.