### PR TITLE
Update returned type from load and loads

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,18 +32,18 @@ If no binary is available on pypi for you system configuration; you'll need rust
 
 #### load
 ```python
-def load(toml: Union[str, Path, TextIO]) -> Any: ...
+def load(toml: Union[str, Path, TextIO]) -> Dict[str, Any]: ...
 ```
 
-Parse TOML via a string or file and return a python object. The `toml` argument may be a `str`,
+Parse TOML via a string or file and return a python dictionary. The `toml` argument may be a `str`,
 `Path` or file object from `open()`.
 
 #### loads
 ```python
-def loads(toml: str) -> Any: ...
+def loads(toml: str) -> Dict[str, Any]: ...
 ```
 
-Parse a TOML string and return a python object. (provided to match the interface of `json` and similar libraries)
+Parse a TOML string and return a python dictionary. (provided to match the interface of `json` and similar libraries)
 
 #### dumps
 ```python

--- a/rtoml/__init__.py
+++ b/rtoml/__init__.py
@@ -15,7 +15,7 @@ TomlSerializationError = _rtoml.TomlSerializationError
 
 def load(toml: Union[str, Path, TextIO]) -> Dict[str, Any]:
     """
-    Parse TOML via a string or file and return a python dictionary. The `toml` argument may be a `str`,
+    Parse TOML via a string or file and return a python dict. The `toml` argument may be a `str`,
     `Path` or file object from `open()`.
     """
     if isinstance(toml, Path):
@@ -28,7 +28,7 @@ def load(toml: Union[str, Path, TextIO]) -> Dict[str, Any]:
 
 def loads(toml: str) -> Dict[str, Any]:
     """
-    Parse a TOML string and return a python dictionary. (provided to match the interface of `json` and similar libraries)
+    Parse a TOML string and return a python dict. (provided to match the interface of `json` and similar libraries)
     """
     if not isinstance(toml, str):
         raise TypeError(f'invalid toml input, must be str not {type(toml)}')

--- a/rtoml/__init__.py
+++ b/rtoml/__init__.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime, time, timezone
 from io import TextIOBase
 from pathlib import Path
-from typing import Any, TextIO, Union
+from typing import Any, Dict, TextIO, Union
 
 from . import _rtoml
 
@@ -13,9 +13,9 @@ TomlParsingError = _rtoml.TomlParsingError
 TomlSerializationError = _rtoml.TomlSerializationError
 
 
-def load(toml: Union[str, Path, TextIO]) -> Any:
+def load(toml: Union[str, Path, TextIO]) -> Dict[str, Any]:
     """
-    Parse TOML via a string or file and return a python object. The `toml` argument may be a `str`,
+    Parse TOML via a string or file and return a python dictionary. The `toml` argument may be a `str`,
     `Path` or file object from `open()`.
     """
     if isinstance(toml, Path):
@@ -26,9 +26,9 @@ def load(toml: Union[str, Path, TextIO]) -> Any:
     return loads(toml)
 
 
-def loads(toml: str) -> Any:
+def loads(toml: str) -> Dict[str, Any]:
     """
-    Parse a TOML string and return a python object. (provided to match the interface of `json` and similar libraries)
+    Parse a TOML string and return a python dictionary. (provided to match the interface of `json` and similar libraries)
     """
     if not isinstance(toml, str):
         raise TypeError(f'invalid toml input, must be str not {type(toml)}')


### PR DESCRIPTION
closes #20

Hi @samuelcolvin,
To your request, the pull request for #20 

Returned Dict[str, Any].

I used Dict from typing so it's compatible with Python >= 3.5 ([the new way `dict[str, Any]` is valid from 3.9 only](https://docs.python.org/3.9/library/typing.html#typing.Dict))

It is consistent aslo with others libraries such as [toml](https://github.com/uiri/toml/blob/master/toml/decoder.pyi#L27) that typed as `Type[MutableMapping[str, Any]]` (And since Dict is a type mixin of dict and MutableMapping, it is almost the same.)

Have a nice day, 
Gil.