### PR TITLE
Benchmark against pytomlpp and tomli

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A better TOML library for python implemented in rust.
 library, it passes all the [standard TOML tests](https://github.com/BurntSushi/toml-test) as well as having 100%
 coverage on python code. Other TOML libraries for python I tried all failed to parse some valid TOML.
 * Performance: see [benchmarks](https://github.com/samuelcolvin/rtoml/tree/main/benchmarks) -
-  rtoml is much faster than other TOML libraries for python.
+  rtoml is much faster than pure Python TOML libraries.
 
 ## Install
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -9,11 +9,11 @@ and
 
 Time taken to load [`data.toml`](https://github.com/samuelcolvin/rtoml/blob/main/benchmarks/data.toml):
 ```
-rtoml     version: 0.6.1    0.272 ms/parse
-pytomlpp  version: 2.4.0    0.249 ms/parse (1.09 X faster)
-tomli     version: 0.2.7    1.799 ms/parse (6.62 X slower)
-uiri/toml version: 0.10.2   2.675 ms/parse (9.84 X slower)
-tomlkit   version: 0.7.2    15.726 ms/parse (57.88 X slower)
+rtoml     version: 0.6.1    0.280 ms/parse
+pytomlpp  version: 2.4.0    0.255 ms/parse (1.10 X faster)
+tomli     version: 0.2.8    1.519 ms/parse (5.42 X slower)
+uiri/toml version: 0.10.2   2.718 ms/parse (9.71 X slower)
+tomlkit   version: 0.7.2    15.757 ms/parse (56.26 X slower)
 ```
 
 See [`run.py`](https://github.com/samuelcolvin/rtoml/blob/main/benchmarks/run.py) for details on how

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,12 +1,19 @@
 # rtoml benchmarks
 
-Versus [uiri/toml](https://github.com/uiri/toml) and [sdispater/tomlkit](https://github.com/sdispater/tomlkit).
+Versus
+[bobfang1992/pytomlpp](https://github.com/bobfang1992/pytomlpp),
+[hukkinj1/tomli](https://github.com/hukkinj1/tomli),
+[uiri/toml](https://github.com/uiri/toml),
+and
+[sdispater/tomlkit](https://github.com/sdispater/tomlkit).
 
 Time taken to load [`data.toml`](https://github.com/samuelcolvin/rtoml/blob/main/benchmarks/data.toml):
 ```
-rtoml     version: 0.2.0    0.221 ms/parse
-uiri/toml version: 0.10.0   1.977 ms/parse (8.96 X slower)
-tomlkit   version: 0.5.8    13.950 ms/parse (63.23 X slower)
+rtoml     version: 0.6.1    0.272 ms/parse
+pytomlpp  version: 2.4.0    0.249 ms/parse (1.09 X faster)
+tomli     version: 0.2.7    1.799 ms/parse (6.62 X slower)
+uiri/toml version: 0.10.2   2.675 ms/parse (9.84 X slower)
+tomlkit   version: 0.7.2    15.726 ms/parse (57.88 X slower)
 ```
 
 See [`run.py`](https://github.com/samuelcolvin/rtoml/blob/main/benchmarks/run.py) for details on how

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -2,7 +2,9 @@
 import timeit
 from pathlib import Path
 
+import pytomlpp
 import toml as uiri_toml
+import tomli
 import tomlkit
 
 import rtoml
@@ -17,6 +19,11 @@ def rtoml_load():
 def uiri_toml_load():
     return uiri_toml.loads(toml_str)
 
+def tomli_load():
+    return tomli.loads(toml_str)
+
+def pytomlpp_load():
+    return pytomlpp.loads(toml_str)
 
 def tomlkit_load():
     return tomlkit.parse(toml_str)
@@ -27,6 +34,8 @@ def test_matching_output():
     # debug(rtoml_data)
     assert rtoml_data == uiri_toml_load()
     assert rtoml_data == tomlkit_load()
+    assert rtoml_data == tomli_load()
+    assert rtoml_data == pytomlpp_load()
 
 
 if __name__ == '__main__':
@@ -34,6 +43,18 @@ if __name__ == '__main__':
 
     rtoml_time = timeit.timeit(rtoml_load, number=steps)
     print(f'rtoml     version: {rtoml.VERSION:8} {rtoml_time / steps * 1000:0.3f} ms/parse')
+
+    pytomlpp_time = timeit.timeit(pytomlpp_load, number=steps)
+    print(
+        f'pytomlpp  version: {pytomlpp.lib_version:8} {pytomlpp_time / steps * 1000:0.3f} ms/parse '
+        f'({rtoml_time / pytomlpp_time:0.2f} X faster)'
+    )
+
+    tomli_time = timeit.timeit(tomli_load, number=steps)
+    print(
+        f'tomli     version: {tomli.__version__:8} {tomli_time / steps * 1000:0.3f} ms/parse '
+        f'({tomli_time / rtoml_time:0.2f} X slower)'
+    )
 
     toml_time = timeit.timeit(uiri_toml_load, number=steps)
     print(


### PR DESCRIPTION
Added pytomlpp and Tomli to the benchmark. I re-ran the benchmark in a clean venv, using CPython 3.8.5 on a `Intel i5-8350U CPU @ 1.70GHz` cpu.