### PR TITLE
Use UTF-8 encoding when reading and writing TOML files

### DIFF
--- a/rtoml/__init__.py
+++ b/rtoml/__init__.py
@@ -18,7 +18,7 @@ def load(toml: Union[str, Path, TextIO]) -> Dict[str, Any]:
     `Path` or file object from `open()`.
     """
     if isinstance(toml, Path):
-        toml = toml.read_text()
+        toml = toml.read_text(encoding='UTF-8')
     elif isinstance(toml, (TextIOBase, TextIO)):
         toml = toml.read()
 
@@ -56,6 +56,6 @@ def dump(obj: Any, file: Union[Path, TextIO], *, pretty: bool = False) -> int:
     """
     s = dumps(obj, pretty=pretty)
     if isinstance(file, Path):
-        return file.write_text(s)
+        return file.write_text(s, encoding='UTF-8')
     else:
         return file.write(s)

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -49,7 +49,7 @@ def test_dumps_pretty(input_obj, output_toml):
 def test_dump_path(tmp_path, input_obj, output_toml, size):
     p = tmp_path / 'test.toml'
     assert rtoml.dump(input_obj, p) == size
-    assert p.read_text() == output_toml
+    assert p.read_text(encoding='UTF-8') == output_toml
 
 
 def test_dump_file(tmp_path):

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -17,6 +17,8 @@ import rtoml
         # order changed to avoid https://github.com/alexcrichton/toml-rs/issues/142
         ({'x': {'a': 1}, 'y': 4}, 'y = 4\n\n[x]\na = 1\n'),
         ((1, 2, 3), '[1, 2, 3]'),
+        ({'emoji': '😷'}, 'emoji = "😷"\n'),
+        ({'polish': 'Witaj świecie'}, 'polish = "Witaj świecie"\n'),
     ],
 )
 def test_dumps(input_obj, output_toml):
@@ -36,10 +38,18 @@ def test_dumps_pretty(input_obj, output_toml):
     assert rtoml.dumps(input_obj, pretty=True) == output_toml
 
 
-def test_dump_path(tmp_path):
+@pytest.mark.parametrize(
+    'input_obj,output_toml,size',
+    [
+        ({'foo': 'bar'}, 'foo = "bar"\n', 12),
+        ({'emoji': '😷'}, 'emoji = "😷"\n', 12),
+        ({'polish': 'Witaj świecie'}, 'polish = "Witaj świecie"\n', 25),
+    ],
+)
+def test_dump_path(tmp_path, input_obj, output_toml, size):
     p = tmp_path / 'test.toml'
-    assert rtoml.dump({'foo': 'bar'}, p) == 12
-    assert p.read_text() == 'foo = "bar"\n'
+    assert rtoml.dump(input_obj, p) == size
+    assert p.read_text() == output_toml
 
 
 def test_dump_file(tmp_path):

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -159,7 +159,7 @@ def test_load_str():
 )
 def test_load_path(tmp_path, input_toml, output_obj):
     p = tmp_path / 'test.toml'
-    p.write_text(input_toml)
+    p.write_text(input_toml, encoding='UTF-8')
     assert rtoml.load(p) == output_obj
 
 

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -149,10 +149,18 @@ def test_load_str():
     assert rtoml.load('foo = "bar"') == {'foo': 'bar'}
 
 
-def test_load_path(tmp_path):
+@pytest.mark.parametrize(
+    'input_toml,output_obj',
+    [
+        ('foo = "bar"', {'foo': 'bar'}),
+        ('emoji = "😷"', {'emoji': '😷'}),
+        ('polish = "Witaj świecie"', {'polish': 'Witaj świecie'}),
+    ],
+)
+def test_load_path(tmp_path, input_toml, output_obj):
     p = tmp_path / 'test.toml'
-    p.write_text('foo = "bar"')
-    assert rtoml.load(p) == {'foo': 'bar'}
+    p.write_text(input_toml)
+    assert rtoml.load(p) == output_obj
 
 
 def test_load_file(tmp_path):


### PR DESCRIPTION
This avoids a `UnicodeDecodeError` when reading or writing TOML files containing unicode characters, such as emoji or non-latin text, on Windows.

Furthermore, the [TOML specification](https://toml.io/en/v1.0.0#spec) requires files to be encoded in UTF-8.