### PR TITLE
Add missing lockfile to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include Cargo.toml
+include Cargo.toml Cargo.lock
 recursive-include src *
 include LICENSE
 include README.md


### PR DESCRIPTION
Expected by some distribution build systems that auto-vendor cargo dependencies.