### PR TITLE
fix windows aarch64 using `pyo3/generate-import-lib`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,10 +149,9 @@ jobs:
           - os: windows
             target: i686
             python-architecture: x86
-          #  https://github.com/PyO3/maturin-action/issues/237
-          # - os: windows
-          #   target: aarch64
-          #   interpreter: 3.11 3.12
+          - os: windows
+            target: aarch64
+            interpreter: 3.11 3.12
 
     runs-on: ${{ (matrix.os == 'linux' && 'ubuntu') || matrix.os }}-latest
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ Source = "https://github.com/samuelcolvin/rtoml"
 [tool.maturin]
 bindings = "pyo3"
 module-name = "rtoml._rtoml"
-features = ["pyo3/extension-module"]
+features = ["pyo3/extension-module", "pyo3/generate-import-lib"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
As suggested in https://github.com/PyO3/maturin-action/issues/237#issuecomment-1866284088 by @messense.