### PR TITLE
Fixed a copy and paste issue for os: windows in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
             target: aarch64
 
           # windows
-          - os: macos
+          - os: windows
             target: x86_64
           - os: windows
             target: i686


### PR DESCRIPTION
Replaced wrong `os` value by `os: windows`