### PR TITLE
Update Go and toml-test toolchain in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
 
     - uses: actions/setup-go@v5
       with:
-        go-version: latest
+        go-version: "1.23"
 
     - name: run toml-test
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,13 +44,13 @@ jobs:
     - run: ls -lha
     - run: uv run coverage xml
 
-    - uses: actions/setup-go@v1
+    - uses: actions/setup-go@v5
       with:
-        go-version: 1.16.x
+        go-version: latest
 
     - name: run toml-test
       run: |
-        git clone --depth 1 --branch 1.0.0-beta2 https://github.com/BurntSushi/toml-test.git
+        git clone --depth 1 --branch 1.5.0 https://github.com/toml-lang/toml-test
         cd toml-test
         # TODO, fix these tests
         rm tests/valid/datetime-local-date.*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,13 +53,13 @@ jobs:
         git clone --depth 1 --branch v1.5.0 https://github.com/toml-lang/toml-test
         cd toml-test
         # TODO, fix these tests
-        rm tests/valid/datetime-local-date.*
-        rm tests/valid/datetime-local-time.*
-        rm tests/valid/datetime-local.*
-        rm tests/valid/key-empty.*
-        rm tests/invalid/control-comment-del.*
-        rm tests/invalid/integer-positive-bin.*
-        rm tests/invalid/integer-positive-hex.*
+        rm tests/valid/datetime/local-date.*
+        rm tests/valid/datetime/local-time.*
+        rm tests/valid/datetime/local.*
+        rm tests/valid/key/empty.*
+        rm tests/invalid/control/comment-del.*
+        rm tests/invalid/integer/positive-bin.*
+        rm tests/invalid/integer/positive-hex.*
         go build ./cmd/toml-test
         cd ../
         source .venv/bin/activate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
 
     - name: run toml-test
       run: |
-        git clone --depth 1 --branch 1.5.0 https://github.com/toml-lang/toml-test
+        git clone --depth 1 --branch v1.5.0 https://github.com/toml-lang/toml-test
         cd toml-test
         # TODO, fix these tests
         rm tests/valid/datetime-local-date.*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         rm tests/valid/datetime/local-date.*
         rm tests/valid/datetime/local-time.*
         rm tests/valid/datetime/local.*
-        rm tests/valid/key/empty.*
+        rm tests/valid/key/empty*
         rm tests/invalid/control/comment-del.*
         rm tests/invalid/integer/positive-bin.*
         rm tests/invalid/integer/positive-hex.*


### PR DESCRIPTION
Hey 👋🏻 

Dependabot bumped `rtoml` for me in one of my projects and I got nosey and decided to look through the repo, I noticed you're using a very old version of `actions/setup-go` and of the toml-test repo (now under the `toml-lang` org rather than `BurntSushi`) so I've updated them in this PR.

I've obviously made the assumption that you _want_ newer versions and weren't pinning for some specific reason so feel free to close this if that's the case 🙂 